### PR TITLE
Revert "use eslint as peerDependency instead of direct dependency"

### DIFF
--- a/packages/eslint-config-js-scripts/package.json
+++ b/packages/eslint-config-js-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-js-scripts",
-  "version": "0.0.36",
+  "version": "0.0.35",
   "description": "",
   "main": "./index.js",
   "repository": {
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "babel-eslint": "10.x",
+    "eslint": "6.5.1",
     "eslint-config-airbnb": "18.0.1",
     "eslint-config-prettier": "6.5.0",
     "eslint-plugin-import": "2.18.2",
@@ -29,9 +30,6 @@
   },
   "devDependencies": {
     "prettier-config-js-scripts": "x"
-  },
-  "peerDependencies": {
-    "eslint": "6.x"
   },
   "prettier": "prettier-config-js-scripts"
 }


### PR DESCRIPTION
Reverts credijusto/js-scripts#27