### PR TITLE
Do not throw error when no matching files 

### DIFF
--- a/packages/js-scripts/package.json
+++ b/packages/js-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-scripts",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "engines": {
     "node": ">=8.10"
   },

--- a/packages/js-scripts/scripts/lint.js
+++ b/packages/js-scripts/scripts/lint.js
@@ -78,6 +78,7 @@ const tasks = new Listr(
               execa('stylelint', [
                 `${sourceDir}/**/*.(${cssExtensions})`,
                 ...(isCIEnvironment ? [] : ['--fix']),
+                '--allow-empty-input',
               ]),
           },
         ]),


### PR DESCRIPTION
As we have removed every pcss file in ui-components, style-lint throws an error due it does not find any pcss file. 

With the option `--allow-empty-input` we should receive any error for these cases 